### PR TITLE
Removed unnecessary async/await methods

### DIFF
--- a/WPNest/WPNest/MainPage/NestViewModel.cs
+++ b/WPNest/WPNest/MainPage/NestViewModel.cs
@@ -192,13 +192,13 @@ namespace WPNest {
 			IsAway = firstStructure.IsAway;
 		}
 
-		public async Task InitializeAsync() {
+		public Task InitializeAsync() {
 			if (_sessionProvider.IsSessionExpired) {
 				State = NestViewModelState.LoggingIn;
-				return;
+				return null;
 			}
 
-			await OnLoggedIn();
+			return OnLoggedIn();
 		}
 
 		public async Task LogInAsync() {
@@ -257,24 +257,24 @@ namespace WPNest {
 			_statusUpdater.Stop();
 		}
 
-		public async Task RaiseLowTemperatureAsync() {
-			await RaiseTemperatureAsync(TemperatureMode.RangeLow);
+		public Task RaiseLowTemperatureAsync() {
+			return RaiseTemperatureAsync(TemperatureMode.RangeLow);
 		}
 
-		public async Task RaiseHighTemperatureAsync() {
-			await RaiseTemperatureAsync(TemperatureMode.RangeHigh);
+		public Task RaiseHighTemperatureAsync() {
+			return RaiseTemperatureAsync(TemperatureMode.RangeHigh);
 		}
 
-		public async Task LowerLowTemperatureAsync() {
-			await LowerTemperatureAsync(TemperatureMode.RangeLow);
+		public Task LowerLowTemperatureAsync() {
+			return LowerTemperatureAsync(TemperatureMode.RangeLow);
 		}
 
-		public async Task LowerHighTemperatureAsync() {
-			await LowerTemperatureAsync(TemperatureMode.RangeHigh);
+		public Task LowerHighTemperatureAsync() {
+			return LowerTemperatureAsync(TemperatureMode.RangeHigh);
 		}
 
-		public async Task RaiseTemperatureAsync() {
-			await RaiseTemperatureAsync(TemperatureMode.Target);
+		public Task RaiseTemperatureAsync() {
+			return RaiseTemperatureAsync(TemperatureMode.Target);
 		}
 
 		private double GetTemperatureValue(TemperatureMode temperatureMode) {
@@ -305,12 +305,12 @@ namespace WPNest {
 				thermostat.TargetTemperature = targetValue;
 		}
 
-		private async Task RaiseTemperatureAsync(TemperatureMode temperatureMode) {
+		private Task RaiseTemperatureAsync(TemperatureMode temperatureMode) {
 			double temperature = GetTemperatureValue(temperatureMode);
 			if (temperature >= MaxTemperature)
-				return;
+				return null;
 
-			await PauseStatusProviderWhile(async () => {
+			return PauseStatusProviderWhile(async () => {
 				var thermostat = GetFirstThermostat();
 
 				double desiredTemperature = temperature + 1.0d;
@@ -325,16 +325,16 @@ namespace WPNest {
 			});
 		}
 
-		public async Task LowerTemperatureAsync() {
-			await LowerTemperatureAsync(TemperatureMode.Target);
+		public Task LowerTemperatureAsync() {
+			return LowerTemperatureAsync(TemperatureMode.Target);
 		}
 
-		public async Task LowerTemperatureAsync(TemperatureMode temperatureMode) {
+		public Task LowerTemperatureAsync(TemperatureMode temperatureMode) {
 			double temperature = GetTemperatureValue(temperatureMode);
-			if (temperature <= MinTemperature)
-				return;
+            if (temperature <= MinTemperature)
+                return null;
 
-			await PauseStatusProviderWhile(async () => {
+			return PauseStatusProviderWhile(async () => {
 				var thermostat = GetFirstThermostat();
 				double desiredTemperature = temperature - 1.0d;
 				SetTemperatureValue(temperatureMode, desiredTemperature);

--- a/WPNest/WPNest/Services/NestWebService.cs
+++ b/WPNest/WPNest/Services/NestWebService.cs
@@ -133,25 +133,25 @@ namespace WPNest.Services {
 			return new WebServiceResult(error, exception);
 		}
 
-		public async Task<WebServiceResult> SetFanModeAsync(Thermostat thermostat, FanMode fanMode) {
+		public Task<WebServiceResult> SetFanModeAsync(Thermostat thermostat, FanMode fanMode) {
 			string url = string.Format(@"{0}/v2/put/device.{1}", _sessionProvider.TransportUrl, thermostat.ID);
 			string fanModeString = GetFanModeString(fanMode);
 			string requestString = string.Format("{{\"fan_mode\":\"{0}\"}}", fanModeString);
-			return await SendPutRequestAsync(url, requestString);
+			return SendPutRequestAsync(url, requestString);
 		}
 
-		public async Task<WebServiceResult> SetHvacModeAsync(Thermostat thermostat, HvacMode hvacMode) {
+		public Task<WebServiceResult> SetHvacModeAsync(Thermostat thermostat, HvacMode hvacMode) {
 			string url = string.Format(@"{0}/v2/put/shared.{1}", _sessionProvider.TransportUrl, thermostat.ID);
 			string hvacModeString = _deserializer.GetHvacModeString(hvacMode);
 			string requestString = string.Format("{{\"target_temperature_type\":\"{0}\"}}", hvacModeString);
-			return await SendPutRequestAsync(url, requestString);
+			return SendPutRequestAsync(url, requestString);
 		}
 
-		public async Task<WebServiceResult> SetAwayMode(Structure structure, bool isAway) {
+		public Task<WebServiceResult> SetAwayMode(Structure structure, bool isAway) {
 			string url = string.Format(@"{0}/v2/put/structure.{1}", _sessionProvider.TransportUrl, structure.ID);
 			string requestString = string.Format("{{\"away_timestamp\":{0},\"away\":{1},\"away_setter\":0}}", 
 				_timestampProvider.GetTimestamp(), isAway.ToString().ToLower());
-			return await SendPutRequestAsync(url, requestString);
+			return SendPutRequestAsync(url, requestString);
 		}
 
 		public async Task<WebServiceResult> UpdateTransportUrlAsync() {
@@ -183,12 +183,12 @@ namespace WPNest.Services {
 			throw new InvalidOperationException();
 		}
 
-		public async Task<WebServiceResult> ChangeTemperatureAsync(Thermostat thermostat, double desiredTemperature, TemperatureMode temperatureMode) {
+		public Task<WebServiceResult> ChangeTemperatureAsync(Thermostat thermostat, double desiredTemperature, TemperatureMode temperatureMode) {
 			string temperatureProperty = GetTemperaturePropertyString(thermostat, desiredTemperature, temperatureMode);
 
 			string url = string.Format(@"{0}/v2/put/shared.{1}", _sessionProvider.TransportUrl, thermostat.ID);
 			string requestString = string.Format("{{\"target_change_pending\":true,{0}}}", temperatureProperty);
-			return await SendPutRequestAsync(url, requestString);
+			return SendPutRequestAsync(url, requestString);
 		}
 
 		private static string GetTemperaturePropertyString(Thermostat thermostat, double desiredTemperature, TemperatureMode temperatureMode) {

--- a/WPNest/WPNest/Services/StatusUpdaterService.cs
+++ b/WPNest/WPNest/Services/StatusUpdaterService.cs
@@ -27,8 +27,8 @@ namespace WPNest.Services {
 			_updateStatusTimer.Change(Timeout.Infinite, Timeout.Infinite);
 		}
 
-		public async Task UpdateStatusAsync() {
-			await UpdateStatusAsync(CurrentStructure);
+		public Task UpdateStatusAsync() {
+			return UpdateStatusAsync(CurrentStructure);
 		}
 
 		private async Task UpdateStatusAsync(Structure structure) {

--- a/WPNest/WPNest/Web/WebRequestWrapper.cs
+++ b/WPNest/WPNest/Web/WebRequestWrapper.cs
@@ -28,8 +28,8 @@ namespace WPNest.Web {
 			get { return new WebHeaderCollectionWrapper(_request.Headers); }
 		}
 
-		public async Task<Stream> GetRequestStreamAsync() {
-			return await _request.GetRequestStreamAsync();
+		public Task<Stream> GetRequestStreamAsync() {
+			return _request.GetRequestStreamAsync();
 		}
 
 		public async Task<IWebResponse> GetResponseAsync() {
@@ -37,8 +37,8 @@ namespace WPNest.Web {
 			return new WebResponseWrapper(response);
 		}
 
-		public async Task SetRequestStringAsync(string requestString) {
-			await _request.SetRequestStringAsync(requestString);
+		public Task SetRequestStringAsync(string requestString) {
+			return _request.SetRequestStringAsync(requestString);
 		}
 	}
 }

--- a/WPNest/WPNest/Web/WebResponseWrapper.cs
+++ b/WPNest/WPNest/Web/WebResponseWrapper.cs
@@ -23,8 +23,8 @@ namespace WPNest.Web {
 			return _response.GetResponseStream();
 		}
 
-		public async Task<string> GetResponseStringAsync() {
-			return await _response.GetResponseStringAsync();
+		public Task<string> GetResponseStringAsync() {
+			return _response.GetResponseStringAsync();
 		}
 	}
 }


### PR DESCRIPTION
I am a PhD student in the CS department at the University of Illinois. I'm currently doing research on asynchronous programming in phone applications. I developed a tool that automatically improves async/await usages by doing transformations.

The tool found some opportunities in your application. There was no need to use async/await for some methods. It will decrease the overhead that is caused by async/await state machine and it will simplify the code. Removing async/await does not change the behavior at all.

Are you interested in merging this pull request? If not, please let me know why.

Thanks for your time!
